### PR TITLE
Fixed RN 0.26 warning 'key is not a prop'

### DIFF
--- a/Hyperlink.js
+++ b/Hyperlink.js
@@ -74,10 +74,16 @@ const Hyperlink = React.createClass({
       return component;
     }
 
-    return React.cloneElement(component, component.props, React.Children.map(children, (child) => {
+    const componentProps = {
+      ...component.props,
+      ref: undefined,
+      key: undefined,
+    }
+
+    return React.cloneElement(component, componentProps, React.Children.map(children, (child) => {
       let {type : {displayName} = {}} = child;
       if (typeof child === 'string' && linkify.pretest(child)){
-        return this.linkify(<Text {...component.props} style={component.props.style}>{child}</Text>);
+        return this.linkify(<Text {...componentProps} style={component.props.style}>{child}</Text>);
       }
       if (displayName === 'Text' && !this.isTextNested(child)){
         return this.linkify(child);

--- a/Hyperlink.js
+++ b/Hyperlink.js
@@ -44,6 +44,12 @@ const Hyperlink = React.createClass({
     let elements = [];
     let _lastIndex = 0;
 
+    const componentProps = {
+      ...component.props,
+      ref: undefined,
+      key: undefined,
+    }
+
     try {
       linkify.match(component.props.children).forEach(({index, lastIndex, text, url}) => {
         let nonLinkedText = component.props.children.substring(_lastIndex, index);
@@ -54,15 +60,16 @@ const Hyperlink = React.createClass({
         if (this.props.linkText){
           text = (typeof this.props.linkText === 'function') ? this.props.linkText(url) : this.props.linkText;
         }
+
         elements.push(
-          <Text {...component.props}
+          <Text {...componentProps}
             style={[component.props.style], [this.props.linkStyle]}
-              onPress={() => this.props.onPress && this.props.onPress(url)}
+            onPress={() => this.props.onPress && this.props.onPress(url)}
             key={url}>{text}</Text>
         );
       });
       elements.push(component.props.children.substring(_lastIndex, component.props.children.length));
-      return React.cloneElement(component, component.props, elements);
+      return React.cloneElement(component, componentProps, elements);
     } catch (err) {
       return component;
     }


### PR DESCRIPTION
Fixed this warning

> Warning: Text: `ref` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)