### PR TITLE
Detect if Text.propTypes actually exists for web

### DIFF
--- a/Hyperlink.js
+++ b/Hyperlink.js
@@ -5,6 +5,8 @@
 import React, { Component, PropTypes } from 'react'
 import { View, Text } from 'react-native'
 
+const textPropTypes = Text.propTypes || {};
+
 class Hyperlink extends Component {
 	constructor(props){
 		super(props)
@@ -95,13 +97,13 @@ class Hyperlink extends Component {
 
 Hyperlink.propTypes = {
 	linkify: PropTypes.object,
-	linkStyle: Text.propTypes.style,
+	linkStyle: textPropTypes.style,
 	linkText: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.func,
 	]),
-	onPress: React.PropTypes.func,
-	onLongPress: React.PropTypes.func,
+	onPress: PropTypes.func,
+	onLongPress: PropTypes.func,
 }
 
 module.exports = Hyperlink


### PR DESCRIPTION
I'm using [react-native-web](https://github.com/necolas/react-native-web) in conjunction with this library in order to support more platforms with the same codebase.

When building our app for development, everything works properly and this library does exactly what we need it to.

However, react-native-web excludes propTypes when you do a production build in order to reduce bundle size and improve performance.

This leads to [issues](https://github.com/necolas/react-native-web/issues/423) when libraries depend on propTypes being defined.

I propose feature-detecting whether Text.propTypes is actually defined so that people using react-native-web, or any bundlers for native that reduce size agressively, without affecting current users.