### PR TITLE
Only set componentProps.onLongPress if this.props.onLongPress is set

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@ var Hyperlink = function (_Component) {
           _lastIndex = lastIndex;
           if (_this2.props.linkText) text = typeof _this2.props.linkText === 'function' ? _this2.props.linkText(url) : _this2.props.linkText;
 
-          if (OS !== 'web') {
+          if (OS !== 'web' && _this2.props.onLongPress) {
             componentProps.onLongPress = function () {
               return _this2.props.onLongPress && _this2.props.onLongPress(url, text);
             };

--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -77,7 +77,7 @@ class Hyperlink extends Component {
               ? this.props.linkText(url)
               : this.props.linkText
 
-        if (OS !== 'web') {
+        if (OS !== 'web' && this.props.onLongPress) {
           componentProps.onLongPress = () => this.props.onLongPress && this.props.onLongPress(url, text)
         }
 


### PR DESCRIPTION
Setting `onLongPress` makes the whole component "pressable", even if the callback does nothing. "Pressable" components will capture press gestures, which means any ancestor components that might want to capture press gestures will be unable to do so.

We should only set `onLongPress` if we have a callback to call, so that any ancestor components that might want to capture a press gesture can do so.