### PR TITLE
Normalize link protocol to lowercase so Android can recognize it

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,10 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _reactNative = require('react-native');
 
+var _mdurl = require('mdurl');
+
+var _mdurl2 = _interopRequireDefault(_mdurl);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -196,8 +200,12 @@ var _class = function (_Component2) {
   _createClass(_class, [{
     key: 'handleLink',
     value: function handleLink(url) {
-      _reactNative.Linking.canOpenURL(url).then(function (supported) {
-        return supported && _reactNative.Linking.openURL(url);
+      var urlObject = _mdurl2.default.parse(url);
+      urlObject.protocol = urlObject.protocol.toLowerCase();
+      var normalizedURL = _mdurl2.default.format(urlObject);
+
+      _reactNative.Linking.canOpenURL(normalizedURL).then(function (supported) {
+        return supported && _reactNative.Linking.openURL(normalizedURL);
       });
     }
   }, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,6 +2133,11 @@
         "js-tokens": "3.0.2"
       }
     },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/obipawan/hyperlink#readme",
   "dependencies": {
-    "linkify-it": "^1.2.0"
+    "linkify-it": "^1.2.0",
+    "mdurl": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -10,6 +10,7 @@ import {
 	Linking, 
 	Platform
 } from 'react-native'
+import mdurl from 'mdurl';
 
 const textPropTypes = Text.propTypes || {}
 const { OS } = Platform
@@ -140,8 +141,12 @@ export default class extends Component {
   }
 
   handleLink (url) {
-	Linking.canOpenURL(url)
-		.then(supported => supported && Linking.openURL(url))
+    const urlObject = mdurl.parse(url);
+    urlObject.protocol = urlObject.protocol.toLowerCase();
+    const normalizedURL = mdurl.format(urlObject)
+
+    Linking.canOpenURL(normalizedURL)
+      .then(supported => supported && Linking.openURL(normalizedURL));
   }
 
   render () {


### PR DESCRIPTION
`Linking.canOpenURL` on Android returns false if the protocol in your URL is not lowercase, eg. "HTtp://google.com". This PR makes sure the URL we pass `Linking.canOpenURL` always has a lowercased protocol.