### PR TITLE
Handle linkify prop being optional

### DIFF
--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -19,7 +19,7 @@ class Hyperlink extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.linkify !== prevState.linkifyIt) {
       return {
-        linkifyIt: nextProps.linkify
+        linkifyIt: nextProps.linkify || require('linkify-it')(),
       };
     }
 


### PR DESCRIPTION
This fixes https://github.com/obipawan/react-native-hyperlink/issues/44