### PR TITLE
injectViewProps #43

### DIFF
--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -90,6 +90,7 @@ class Hyperlink extends Component {
             { ...clickHandlerProps }
             key={ url + index }
             style={ [ component.props.style, this.props.linkStyle ] }
+            { ...this.props.injectViewProps(url) }
           >
             { text }
           </Text>
@@ -134,9 +135,10 @@ Hyperlink.propTypes = {
   ]),
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
+  injectViewProps: PropTypes.func,
 }
 
-Hyperlink.defaultProps = { linkify }
+Hyperlink.defaultProps = { linkify, injectViewProps: i => ({}) }
 
 Hyperlink.getDerivedStateFromProps = (nextProps, prevState) => (nextProps.linkify !== prevState.linkifyIt)
     ? { linkifyIt: nextProps.linkify }


### PR DESCRIPTION
Lets a clickable component be injected with additional props for the given url

A trivial example to inject [TestID](https://facebook.github.io/react-native/docs/view#testid)

```
<Hyperlink
  ...
  injectViewProps={ url => ({ testID: url === 'some url' ? 'id1' : 'id2' }) }
>
  ...
  ...
</Hyperlink>
```