### PR TITLE
Fixed props key was spread into JSX

### DIFF
--- a/src/Hyperlink.tsx
+++ b/src/Hyperlink.tsx
@@ -72,11 +72,9 @@ class Hyperlink extends Component<HyperlinkProps, HyperlinkState> {
 		let elements = [];
 		let _lastIndex = 0;
 
-		const componentProps = {
-			...component.props,
-			ref: undefined,
-			key: undefined,
-		};
+		const componentProps = {...component.props};
+		delete componentProps.key;
+		delete componentProps.ref;
 
 		try {
 			this.state.linkifyIt


### PR DESCRIPTION


Hi,

With the last version of react-native (0.75.4), the package display a warning for a deprecated code :

```
 ERROR  Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage key={someKey} {...props} />
```

So I create this PR to fix it. As you can see, it’s really a light commit.

This PR work with last react-native version and previous one.

Do you think create a new npm patch 0.0.23 to add this modification ?

Thanks for reading.
