### PR TITLE
fix: replace delete with destructuring to support React Native 0.82+ …

### DIFF
--- a/src/Hyperlink.tsx
+++ b/src/Hyperlink.tsx
@@ -96,10 +96,7 @@ class Hyperlink extends Component<HyperlinkProps, HyperlinkState> {
 		let elements: Array<string | React.ReactElement> = [];
 		let _lastIndex = 0;
 
-		// Create component props (ref and key are React-specific and not in TextProps)
-		const componentProps = component.props as TextProps;
-		delete (componentProps as { ref?: unknown }).ref;
-		delete (componentProps as { key?: unknown }).key;
+		const { ref: _ref, key: _key, ...componentProps } = component.props || {};
 
 		try {
 			this.state.linkifyIt
@@ -161,9 +158,7 @@ class Hyperlink extends Component<HyperlinkProps, HyperlinkState> {
 		let { props: { children } = { children: undefined } } = component || {};
 		if (!children) return component;
 
-		const componentProps = component.props as TextProps;
-		delete (componentProps as { ref?: unknown }).ref;
-		delete (componentProps as { key?: unknown }).key;
+		const { ref: _ref, key: _key, ...componentProps } = component.props || {};
 
 		return React.cloneElement(
 			component,


### PR DESCRIPTION
## Description
Fixes the `TypeError: Property 'ref' is not configurable` error that occurs when using this library with React Native 0.82+ and the new architecture (Fabric) enabled.

## Changes
- Replaced `delete` operations with object destructuring in the `linkify` method
- Replaced `delete` operations with object destructuring in the `parse` method

## Problem
The library was attempting to delete the `ref` property from component props, which is not allowed in React Native's new architecture as the `ref` property is non-configurable.

## Solution
Instead of mutating props by deleting `ref` and `key`, we now use object destructuring to create a new object without these properties:
```javascript
const { ref: _ref, key: _key, ...componentProps } = component.props || {};
```

## Testing
- ✅ Tested with React Native 0.82.1 with new architecture enabled
- ✅ Backward compatible with older React Native versions
- ✅ No breaking changes to existing API

## Fixes
Closes #85