### PR TITLE
fix: app crash on open non protocol link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm i --save react-native-hyperlink
 | `linkText` | A string or a func to replace parsed text | `oneOfType([ string, func ])` |
 | `onPress` | Func to handle click over a clickable text with parsed text as arg | `func` |
 | `onLongPress` | Func to handle long click over a clickable text with parsed text as arg | `func` |
+| `onLinkError` | Func to handle errors when `Linking.openURL` fails (used with `linkDefault`) | `func` |
 |`linkDefault`|A platform specific fallback to handle `onPress`. Uses [Linking](https://facebook.github.io/react-native/docs/linking.html). Disabled by default | `bool`
 |`injectViewProps`| Func with url as a param to inject props to the clickable component | `func` | `i => ({})`
 

--- a/src/Hyperlink.tsx
+++ b/src/Hyperlink.tsx
@@ -203,11 +203,14 @@ export default class extends Component<HyperlinkProps> {
 
 	handleLink(url: string) {
 		const urlObject = parse(url);
-		urlObject.protocol = urlObject.protocol.toLowerCase();
+		urlObject.protocol = urlObject.protocol?.toLowerCase() ?? '';
 		const normalizedURL = format(urlObject);
 
 		Linking.canOpenURL(normalizedURL).then((supported: boolean) => {
-			supported && Linking.openURL(normalizedURL);
+			if (!supported) return;
+			Linking.openURL(normalizedURL).catch(error => {
+				if (this.props.onLinkError) this.props.onLinkError(error);
+			});
 		});
 	}
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { Text, View, Linking, Platform } from 'react-native';
 import Hyperlink from '../index';
 
@@ -659,6 +659,42 @@ describe('Hyperlink', () => {
 
 			pretestSpy.mockRestore();
 			testSpy.mockRestore();
+		});
+	});
+
+	describe('errors', () => {
+		// mdurl.parse returns protocol as null for url like this
+		const url = '//example.com';
+
+		it('should handle invalid link gracefully', () => {
+			expect(() => {
+				const { getByText } = render(
+					<Hyperlink linkDefault>
+						<Text>Visit our site at {url}</Text>
+					</Hyperlink>,
+				);
+				fireEvent.press(getByText(url));
+			}).not.toThrow();
+		});
+
+		it('should handle openURL fail gracefully and pass error', async () => {
+			const mockError = new Error('Failed to open');
+			const mockOnError = jest.fn();
+			jest.spyOn(Linking, 'openURL').mockRejectedValueOnce(mockError);
+
+			const { getByText } = render(
+				<Hyperlink
+					linkDefault
+					onLinkError={mockOnError}
+				>
+					<Text>Visit our site at {url}</Text>
+				</Hyperlink>,
+			);
+			fireEvent.press(getByText(url));
+
+			await waitFor(() => {
+				expect(mockOnError).toHaveBeenCalledWith(mockError);
+			});
 		});
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type HyperlinkProps = {
 	linkText?: ((url: string) => string) | string;
 	onPress?: (url: string, text?: string) => void;
 	onLongPress?: (url: string, text?: string) => void;
+	onLinkError?: (error: unknown) => void;
 	injectViewProps?: (url: string) => TextProps;
 	style?: ViewProps['style'];
 	children?: ReactElementWithType;


### PR DESCRIPTION
## Description

Fixes the `TypeError: Cannot read property 'toLowerCase'` that occurs when open `//example.com` link.

## Changes

- added optional chaining for `protocol.toLowerCase()` and nullish coalescing to empty string
- catch added to `Linking.openURL`
    - `onLinkError` added to props for passing error that could happen on `Linking.openURL`

## Problem

Pressing on `//example.com` link leads to App crash right now. That’s because `mdurl.parse` **returns protocol as null for url like this (even though TS shows `Url.protocol: string`).

After `TypeError` fix `Linking.openURL` fails, so it also should be addressed.

## Solution

While [[//example.com](https://example.com/)](https://example.com/) invalid for RN, it’s actually valid link for web browsers, so it shouldn’t be prohibited.

So make protocol empty string (which it is for given link), and handle `openURL` error. Also add link error handler, so lib users could get actual error and handle it.

## Testing

- ✅ Tested with React Native 0.82.1 with new architecture enabled
- ✅ Backward compatible with older React Native versions
- ✅ No breaking changes to existing API
- ✅ New unit tests added